### PR TITLE
Added ability to specify max size of the stack

### DIFF
--- a/lib/stack.dart
+++ b/lib/stack.dart
@@ -6,6 +6,22 @@ import 'package:stack/illegal_operation_exception.dart';
 
 class Stack<T> {
   final ListQueue<T> _list = ListQueue();
+  int _sizeMax = 0;
+
+  /// default constructor sets the maximum stack size to 1 million entries
+  Stack() : this.sized( 1000000 );
+
+  /// constructor if user wants to specify maximum number of entries
+  Stack.sized(int sizeMax ) {
+    if( sizeMax < 2 ) {
+      throw IllegalOperationException(
+        'Error: stack size must be 2 or more '
+      );
+    }
+    else {
+      _sizeMax = sizeMax;
+    }
+  }
 
   /// check if the stack is empty.
   bool get isEmpty => _list.isEmpty;
@@ -15,7 +31,13 @@ class Stack<T> {
 
   /// push element in top of the stack.
   void push(T e) {
-    _list.addLast(e);
+    if( _list.length < _sizeMax ) {
+      _list.addLast(e);
+    }
+    else {
+      throw IllegalOperationException(
+        'Error: cannot add elements to stack already at maximum size' );
+    }
   }
 
   /// get the top of the stack and delete it.

--- a/lib/stack.dart
+++ b/lib/stack.dart
@@ -6,16 +6,25 @@ import 'package:stack/illegal_operation_exception.dart';
 
 class Stack<T> {
   final ListQueue<T> _list = ListQueue();
+
+  final int noLimit = -1;
+
+  /// the maximum number of entries allowed on the stack. -1 = no limit.
   int _sizeMax = 0;
 
-  /// default constructor sets the maximum stack size to 1 million entries
-  Stack() : this.sized( 1000000 );
+  /// Default constructor sets the maximum stack size to 'no limit.'
+  Stack() {
+    _sizeMax = noLimit;
+  }
 
-  /// constructor if user wants to specify maximum number of entries
-  Stack.sized(int sizeMax ) {
-    if( sizeMax < 2 ) {
+  /// Constructor in which you can specify maximum number of entries.
+  /// This maximum is a limit that is enforced as entries are pushed on to the stack
+  /// to prevent stack growth beyond a maximum size. There is no pre-allocation of
+  /// slots for entries at any time in this library.
+  Stack.sized(int sizeMax) {
+    if(sizeMax < 2) {
       throw IllegalOperationException(
-        'Error: stack size must be 2 or more '
+        'Error: stack size must be 2 entries or more '
       );
     }
     else {
@@ -31,12 +40,12 @@ class Stack<T> {
 
   /// push element in top of the stack.
   void push(T e) {
-    if( _list.length < _sizeMax ) {
+    if(_sizeMax == noLimit || _list.length < _sizeMax) {
       _list.addLast(e);
     }
     else {
       throw IllegalOperationException(
-        'Error: cannot add elements to stack already at maximum size' );
+        'Error: cannot add element. Stack already at maximum size of: ${_sizeMax} elements');
     }
   }
 

--- a/test/stack_test.dart
+++ b/test/stack_test.dart
@@ -8,7 +8,7 @@ void main() {
   group('with string', () {
     test('illegal size stack', () {
       try {
-        Stack<String> stack = Stack.sized( 1 );
+        Stack<String> stack = Stack.sized(1);
         fail('should throw an exception but it did not.');
       } catch (ex) {
         expect(ex, isA<IllegalOperationException>());
@@ -31,7 +31,7 @@ void main() {
       stack.push('abc');
     });
     test('push beyond maximum stack size', () {
-      Stack<String> stack = Stack.sized( 2 );
+      Stack<String> stack = Stack.sized(2);
       try {
         stack.push('abc');
         stack.push('def');

--- a/test/stack_test.dart
+++ b/test/stack_test.dart
@@ -6,6 +6,15 @@ import 'package:test/test.dart';
 
 void main() {
   group('with string', () {
+    test('illegal size stack', () {
+      try {
+        Stack<String> stack = Stack.sized( 1 );
+        fail('should throw an exception but it did not.');
+      } catch (ex) {
+        expect(ex, isA<IllegalOperationException>());
+      }
+    });
+
     test('is empty', () {
       Stack<String> stack = Stack();
       expect(stack.isEmpty, true);
@@ -20,6 +29,17 @@ void main() {
     test('push', () {
       Stack<String> stack = Stack();
       stack.push('abc');
+    });
+    test('push beyond maximum stack size', () {
+      Stack<String> stack = Stack.sized( 2 );
+      try {
+        stack.push('abc');
+        stack.push('def');
+        stack.push('ghi');
+        fail('should throw an exception for exceeding stack size, but it did not.');
+      } catch (ex) {
+        expect(ex, isA<IllegalOperationException>());
+      }
     });
     test('top', () {
       Stack<String> stack = Stack();


### PR DESCRIPTION
It's often valuable to limit the size of a stack, so that they don't consume more memory than expected. This PR adds max stack size. In the default constructor, the max size defaults to 1 million entries as the max. To specify the maximum explicitly call Stack.sized()